### PR TITLE
Step4 pull request

### DIFF
--- a/db/items.db
+++ b/db/items.db
@@ -1,21 +1,2 @@
-# sqlite3を起動
-sqlite3 mercari.sqlite3
-
-# itemsテーブルを作成
-create table items(id integer primary key, name text, category text, image_name text);
-
-# 存在するテーブルを確認
-.tables
-
-# itemsテーブルの情報を確認
-.schema items
-
-#################################
-
-# categoriesテーブルを作成
 create table categories(id integer primary key, name text);
-
-# itemsテーブルを作成 
 create table items(id integer primary key, name text, category_id integer, image_name text, foreign key (category_id) references categories(id));
-
-

--- a/db/items.db
+++ b/db/items.db
@@ -1,0 +1,1 @@
+create table items(id int, name text, category text, image_name text);

--- a/db/items.db
+++ b/db/items.db
@@ -1,1 +1,12 @@
-create table items(id int, name text, category text, image_name text);
+# sqlite3を起動
+sqlite3 mercari.sqlite3
+
+# itemsテーブルを作成
+create table items(id integer primary key, name text, category text, image_name text);
+
+# 存在するテーブルを確認
+.tables
+
+# itemsテーブルの情報を確認
+.schema items
+

--- a/db/items.db
+++ b/db/items.db
@@ -10,3 +10,12 @@ create table items(id integer primary key, name text, category text, image_name 
 # itemsテーブルの情報を確認
 .schema items
 
+#################################
+
+# categoriesテーブルを作成
+create table categories(id integer primary key, name text);
+
+# itemsテーブルを作成 
+create table items(id integer primary key, name text, category_id integer, image_name text, foreign key (category_id) references categories(id));
+
+

--- a/python/main.py
+++ b/python/main.py
@@ -55,11 +55,12 @@ def add_item(name: str = Form(...), category: str = Form(...), image: UploadFile
 def save_items_to_sqlite3(name, category, image_name):
     con = sqlite3.connect(sqlite3_file)
     cur = con.cursor()
-    new_item = {"name": name, "category": category, "image_name": image_name}
+    
+    #new_item = {"name": name, "category": category, "image_name": image_name}
     try:
-        cur.execute("INSERT INTO items(name, category, image_name) VALUES (?, ?, ?)", (name, category, image_name))
+        cur.execute("INSERT OR IGNORE INTO items(name, category, image_name) VALUES (?, ?, ?)", (name, category, image_name) )
         con.commit()
-        cur.execute("DELETE FROM items WHERE id NOT IN (SELECT min_id from (SELECT MIN(id) min_id FROM items GROUP BY name,category,image_name) tmp)")
+        logger.debug(f"データを保存しました: {name}")
     except sqlite3.Error as e:
         con.rollback()
         logger.error(f"エラーが発生したためロールバック: {e}")
@@ -102,8 +103,8 @@ def get_hash_by_sha256(image):
 # 商品一覧を取得
 @app.get("/items")
 def get_items():
-    #items = get_items_from_json()
-    items = get_items_from_sqlite()
+    #items = get_items_from_json()    # items.jsonから
+    items = get_items_from_sqlite()    # mercari.sqlite3から
     return items
 
 # items.jsonから商品一覧を取得

--- a/python/main.py
+++ b/python/main.py
@@ -79,9 +79,6 @@ def save_items_to_sqlite3(name, category, image_name):
     con.close()
 
 
-
-
-
 # 新しい商品をitem.jsonファイルに保存
 # {"items": [{"name": "jacket", "category": "fashion", "image_name": "xxxxx.jpg"}, ...]}
 def save_items_to_file(name, category, image_name):
@@ -164,3 +161,20 @@ async def get_image(image_name):
         image = images / "default.jpg"
 
     return FileResponse(image)
+
+
+# 商品をmercari.sqlite3から検索する
+@app.get("/search")
+def search_items(keyword: str):
+    logger.debug(f"Search items name : {keyword}")
+    con = sqlite3.connect(sqlite3_file)
+    cur = con.cursor()
+    items = cur.execute("SELECT * FROM items WHERE name LIKE ?", (f"%{keyword}%",))
+    if not items:
+        logger.debug(f"Items not found: {keyword}")
+    items = cur.fetchall()
+
+    cur.close()
+    con.close()
+    return items
+

--- a/python/main.py
+++ b/python/main.py
@@ -51,19 +51,22 @@ def add_item(name: str = Form(...), category: str = Form(...), image: UploadFile
 
 
 # 新しい商品をmercari_sqlite3ファイルに保存
-# {"items": [{"id": int, "name": string, "category": string, "image_name": string}, ...]}
+# itemsテーブルに既に存在する場合は保存しない
 def save_items_to_sqlite3(name, category, image_name):
     con = sqlite3.connect(sqlite3_file)
     cur = con.cursor()
     
-    #new_item = {"name": name, "category": category, "image_name": image_name}
-    try:
-        cur.execute("INSERT OR IGNORE INTO items(name, category, image_name) VALUES (?, ?, ?)", (name, category, image_name) )
-        con.commit()
-        logger.debug(f"データを保存しました: {name}")
-    except sqlite3.Error as e:
-        con.rollback()
-        logger.error(f"エラーが発生したためロールバック: {e}")
+    cur.execute("SELECT id FROM items WHERE name = ?", (name,))
+    exist_check = cur.fetchall()
+    if not exist_check:
+        logger.debug(f"the item doesn't exist yet. ")
+        try:
+            cur.execute("INSERT OR IGNORE INTO items(name, category, image_name) VALUES (?, ?, ?)", (name, category, image_name) )
+            con.commit()
+            
+        except sqlite3.Error as e:
+            con.rollback()
+            logger.error(f"エラーが発生したためロールバック: {e}")
     con.close()
 
 


### PR DESCRIPTION
## What
<!--- Write the change being made with this pull request --->
Step4を実装してみました。
https://github.com/MisukiAkiyama/mercari-build-training/blob/main/document/04-database.ja.md

SQlite3について調べながら、、、
参考：python3でsqlite3の操作。作成や読み出しなどの基礎。( https://qiita.com/saira/items/e08c8849cea6c3b5eb0c )

### 1. SQliteに情報を移行する
まずはcreate table items でitemsテーブルを作成する。
main.pyにテーブルを作成する関数を書いた。
" sqlite3.OperationalError: table items already exists "　と返されたので、やっぱりコメントアウトした。
ターミナル上でやって良い！

> スキーマをdb/items.dbに保存する

は、ターミナル上で書いた文をdb/items.db に書き込むということらしい！（team4のスレッドより）

### 2. 商品を検索する

辞書を作成して、"items"項目にappendしていく。
参考：パターンマッチングで比較(LIKE句) ( https://www.javadrive.jp/sqlite/select/index6.html )

### 3. カテゴリの情報を別のテーブルに移す

まずcategoriesテーブルを作成して、その次にitemsテーブルを作成。そのときに、**foreign key (category_id) references categories(id)** を加えることで、categoriesのidとitemsのcategory_idが関連つけされる

POST items, GET items, GET items/number, GET search を更新しました。

**category_idを取得するときにつまずいたところ**
・select後の戻り値の型の違い **fetchall()、fetchone()、fetchmary()**
・fetchall()はリストの中にタプル [()]、fetchone()はタプル()
・参考：(Python)SQLite3のSelect結果の取得 ( https://as-chapa.hatenablog.com/entry/python-sqlite3-fetch )

**気をつけること**（Step4の解説より）
・先にcategoriesテーブルを作成して、itemsテーブルをcreateするときにidを紐つける。
・テーブルをjoinする。

**工夫したところ**
・POSTのときに、同じアイテムはテーブルに保存しないようにした。
　(既にnameが同じものが存在していた場合は無視する)

参考にさせていただいたYura InagakiさんのPR ( https://github.com/aiueoyura05/mercari-build-training/pull/3 )

**データベースの正規化について**
データベースの柔軟性を高める。
大規模なデータを扱うにあたって、データ処理が単純になる。

## Please review
- SQlite3のエラー処理はどうすればよいのか

## CHECKS :warning:

Please make sure you are aware of the following.

- [ ] **The changes in this PR doesn't have private information
